### PR TITLE
Specify remote branch when pushing

### DIFF
--- a/pyreleaseplugin/git.py
+++ b/pyreleaseplugin/git.py
@@ -37,11 +37,11 @@ def tag(version):
         raise RuntimeError("Error tagging release")
 
 
-def push_code(release_branch):
+def push_code(branch):
     """
-    Push code changes to git branch `release_branch`.
+    Push code changes to git branch `branch`.
     """
-    code = Popen(["git", "push", "origin", release_branch]).wait()
+    code = Popen(["git", "push", "origin", branch]).wait()
     if code:
         raise RuntimeError("Error pushing changes to git")
 
@@ -55,9 +55,9 @@ def push_tags():
         raise RuntimeError("Error pushing tags to git")
 
 
-def push():
+def push(release_branch):
     """
-    Push the release commits to Github.
+    Push commits and tags to Github.
     """
-    push_code()
+    push_code(release_branch)
     push_tags()

--- a/pyreleaseplugin/git.py
+++ b/pyreleaseplugin/git.py
@@ -37,11 +37,11 @@ def tag(version):
         raise RuntimeError("Error tagging release")
 
 
-def push_code():
+def push_code(release_branch):
     """
-    Push code changes to git.
+    Push code changes to git branch `release_branch`.
     """
-    code = Popen(["git", "push"]).wait()
+    code = Popen(["git", "push", "origin", release_branch]).wait()
     if code:
         raise RuntimeError("Error pushing changes to git")
 

--- a/pyreleaseplugin/release.py
+++ b/pyreleaseplugin/release.py
@@ -250,12 +250,14 @@ class ReleaseCommand(Command):
         tag(self.version)
 
         # push changes to Github
+        # NOTE: this will push from the currently checked out branch to origin/master;
+        # TODO: accommodate releases from other branches
         push_to_master = self.push_to_master or parse_y_n_response(
             input("Would you like to push the changes to master? [y/n] ").strip())
 
         if push_to_master:
             print("Pushing changes to the master branch on Github")
-            push()
+            push("master")
 
         # build and publish
         build()


### PR DESCRIPTION
This is needed for releasing from Jenkins and more importantly, it's a good thing to do in the release plugin.