### PR TITLE
Revert "Use setuptools rather than twine for uploading and specify target repo"

### DIFF
--- a/pyreleaseplugin/release.py
+++ b/pyreleaseplugin/release.py
@@ -174,7 +174,7 @@ def publish_to_pypi():
     """
     Publish the distribution to our local PyPi.
     """
-    code = Popen(["python", "setup.py", "bdist_wheel", "upload", "-r", "artifactory"]).wait()
+    code = Popen(["twine", "upload", "dist/*"]).wait()
     if code:
         raise RuntimeError("Error publishing to PyPi")
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-install_requires_list = []
+install_requires_list = ["twine>=1.7"]
 tests_require = ["pytest>=2.9"]
 
 


### PR DESCRIPTION
Reverts socrata/python-release-plugin#8