### PR TITLE
Print options

### DIFF
--- a/pyreleaseplugin/release.py
+++ b/pyreleaseplugin/release.py
@@ -255,6 +255,17 @@ class ReleaseCommand(Command):
 
         self.push_to_remote = bool(self.push_to_remote)
 
+        print ("Options selected for ReleaseCommand: ")
+        print ("\told_version: %s" % self.old_version)
+        print ("\tversion: %s" % self.version)
+        print ("\tversion_file: %s" % self.version_file)
+        print ("\tno_bump_version: %s" % self.no_bump_version)
+        print ("\tchangelog_file: %s" % self.changelog_file)
+        print ("\tno_update_changelog: %s" % self.no_update_changelog)
+        print ("\tdescription: %s" % self.description)
+        print ("\tpush_to_remote: %s" % self.push_to_remote)
+        print ("\tRepository: %s" % self.repository)
+
     def run(self):
         # fail fast if working tree is not clean
         if not is_tree_clean():

--- a/pyreleaseplugin/release.py
+++ b/pyreleaseplugin/release.py
@@ -19,6 +19,7 @@ specified on the command-line. The full list of allowed command-line options is 
     ("changelog-file=", "c", "a Markdown file containing a log changes"),
     ("no-update-changelog", "C", "do not update a Changlog file"),
     ("push-to-remote", "p", "whether to push to the remote repository")
+    ("repository", "r", "repository to be used by the ReleaseCommand for the artifact upload. If ommitted, repository will be defaulted to PyPi")
 
 
 
@@ -168,11 +169,18 @@ def build():
         raise RuntimeError("Error building wheel")
 
 
-def publish_to_pypi():
+def publish_to_pypi(repository):
     """
     Publish the distribution to our local PyPi.
+    :param repository: the repository to be used by the ReleaseCommand for the artifact upload. If ommitted, repository will be defaulted to PyPi
     """
-    code = Popen(["twine", "upload", "dist/*", "-r", "artifactory"]).wait()
+    cmd = None
+    if repository is None:
+        cmd = ["twine", "upload", "dist/*", "--repository", "pypi"]
+    else:
+        cmd = ["twine", "upload", "dist/*", "--repository", repository]
+
+    code = Popen(cmd).wait()
     if code:
         raise RuntimeError("Error publishing to PyPi")
 

--- a/pyreleaseplugin/release.py
+++ b/pyreleaseplugin/release.py
@@ -230,6 +230,7 @@ class ReleaseCommand(Command):
         self.no_update_changelog = False   # whether to skip changelog updates
         self.description = None            # description text
         self.push_to_remote = None         # whether to push to the remote repository
+        self.repository = self.repository
 
     def finalize_options(self):
         if not os.path.exists(self.version_file):
@@ -294,4 +295,4 @@ class ReleaseCommand(Command):
 
         # build and publish
         build()
-        publish_to_pypi()
+        publish_to_pypi(self.repository)


### PR DESCRIPTION
Updating pull request, for parameterizing respository name instead of hard-coding to artifactory

Add print lines for all options selected for the ReleaseCommand